### PR TITLE
Fix Dutch language item overflow problem

### DIFF
--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -100,7 +100,7 @@
     <string name="menu_add_page">Pagina toevoegen</string>
     <string name="settings_title_page_name_default">Pagina toevoegen</string>
 
-    <string name="custom">Andere munt (U specifieert deze in volgend menu)</string>
+    <string name="custom">Andere munt (Specifieert u hieronder)</string>
     <string name="settings_title_myelectric_custom_currency">Andere munt</string>
     <string name="settings_title_app_information">APP VERSIE: </string>
 


### PR DESCRIPTION
Fixes the dutch text being too long on my phone making it cut off the screen. See https://community.openenergymonitor.org/t/emoncms-android-app-v2-0-1-open-beta-testing/3373/90?u=joyrider3774