### PR TITLE
Fix two letter initials for Thursday

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,7 +86,7 @@
     <string name="monday_initial">Mo</string>
     <string name="tuesday_initial">Tu</string>
     <string name="wednesday_initial">We</string>
-    <string name="thursday_initial">Tu</string>
+    <string name="thursday_initial">Th</string>
     <string name="friday_initial">Fr</string>
     <string name="saturday_initial">Sa</string>
     <string name="sunday_initial">Su</string>


### PR DESCRIPTION
Fix two letter initials for Thursday to Th instead of Tu